### PR TITLE
Download actions/action-versions latest release on win/linux/mac and set ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE.

### DIFF
--- a/images/linux/scripts/installers/action-archive-cache.sh
+++ b/images/linux/scripts/installers/action-archive-cache.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+################################################################################
+##  File:  action-archive-cache.sh
+##  Desc:  Download latest release from https://github.com/actions/action_verions
+##         and un-tar to /opt/actionarchivecache
+################################################################################
+
+# Source the helpers for use with the script
+source $HELPER_SCRIPTS/install.sh
+source $HELPER_SCRIPTS/etc-environment.sh
+
+# Prepare directory and env variable for ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE
+ACTION_ARCHIVE_CACHE_DIR=/opt/actionarchivecache
+mkdir -p $ACTION_ARCHIVE_CACHE_DIR
+chmod -R 777 $ACTION_ARCHIVE_CACHE_DIR
+echo "Setting up ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE variable to ${ACTION_ARCHIVE_CACHE_DIR}"
+addEtcEnvironmentVariable ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE ${ACTION_ARCHIVE_CACHE_DIR}
+
+# Download latest release from github.com/actions/action-versions and untar to /opt/actionarchivecache
+downloadUrl=$(get_github_package_download_url "actions/action-versions" "contains(\"action-versions.tar.gz\")")
+echo "Downloading action-versions $downloadUrl"
+download_with_retries "$downloadUrl" "/tmp" action-versions.tar.gz
+tar -xzf /tmp/action-versions.tar.gz -C $ACTION_ARCHIVE_CACHE_DIR
+
+invoke_tests "ActionArchiveCache"

--- a/images/linux/scripts/tests/ActionArchiveCache.Tests.ps1
+++ b/images/linux/scripts/tests/ActionArchiveCache.Tests.ps1
@@ -1,0 +1,15 @@
+Describe "ActionArchiveCache" {
+    Context "Action archive cache directory not empty" {
+        It "/opt/actionarchivecache not empty" {
+            (Get-ChildItem -Path "/opt/actionarchivecache/*.tar.gz" -Recurse).Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context "Action tarball not empty" {
+        $testCases = Get-ChildItem -Path "/opt/actionarchivecache/*.tar.gz" -Recurse | ForEach-Object { @{ ActionTarball = $_.FullName } }
+        It "<ActionTarball>" -TestCases $testCases {
+            param ([string] $ActionTarball)
+            (Get-Item "$ActionTarball").Length | Should -BeGreaterThan 0
+        }
+    }
+}

--- a/images/linux/ubuntu2004.json
+++ b/images/linux/ubuntu2004.json
@@ -196,6 +196,7 @@
         {
             "type": "shell",
             "scripts": [
+                "{{template_dir}}/scripts/installers/action-archive-cache.sh",
                 "{{template_dir}}/scripts/installers/apt-common.sh",
                 "{{template_dir}}/scripts/installers/azcopy.sh",
                 "{{template_dir}}/scripts/installers/azure-cli.sh",

--- a/images/linux/ubuntu2204.pkr.hcl
+++ b/images/linux/ubuntu2204.pkr.hcl
@@ -280,6 +280,7 @@ build {
     environment_vars = ["HELPER_SCRIPTS=${var.helper_script_folder}", "INSTALLER_SCRIPT_FOLDER=${var.installer_script_folder}", "DEBIAN_FRONTEND=noninteractive"]
     execute_command  = "sudo sh -c '{{ .Vars }} {{ .Path }}'"
     scripts          = [
+                        "${path.root}/scripts/installers/action-archive-cache.sh",
                         "${path.root}/scripts/installers/apt-common.sh",
                         "${path.root}/scripts/installers/azcopy.sh",
                         "${path.root}/scripts/installers/azure-cli.sh",

--- a/images/macos/provision/configuration/environment/bashrc
+++ b/images/macos/provision/configuration/environment/bashrc
@@ -12,6 +12,7 @@ export NUNIT3_PATH=/Library/Developer/nunit/3.6.0
 
 export AGENT_TOOLSDIRECTORY=$HOME/hostedtoolcache
 export RUNNER_TOOL_CACHE=$HOME/hostedtoolcache
+export ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE=$HOME/actionarchivecache
 
 export PATH=/Library/Frameworks/Mono.framework/Versions/Current/Commands:$PATH
 export PATH=/Library/Frameworks/Python.framework/Versions/Current/bin:$PATH

--- a/images/macos/provision/core/action-archive-cache.sh
+++ b/images/macos/provision/core/action-archive-cache.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -e -o pipefail
+
+source ~/utils/utils.sh
+
+echo "Check if ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE folder exist..."
+if [ ! -d $ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE ]; then
+    mkdir -p $ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE
+fi
+
+downloadUrl=$(get_github_package_download_url "actions/action-versions" "contains(\"action-versions.tar.gz\")" "latest")
+echo "Downloading action-versions $downloadUrl"
+download_with_retries "$downloadUrl" "/tmp" action-versions.tar.gz
+tar -xzf /tmp/action-versions.tar.gz -C $ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE
+
+invoke_tests "ActionArchiveCache"

--- a/images/macos/templates/macOS-11.json
+++ b/images/macos/templates/macOS-11.json
@@ -183,6 +183,7 @@
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "scripts": [
+                "./provision/core/action-archive-cache.sh",
                 "./provision/core/commonutils.sh",
                 "./provision/core/llvm.sh",
                 "./provision/core/golang.sh",

--- a/images/macos/templates/macOS-12.anka.pkr.hcl
+++ b/images/macos/templates/macOS-12.anka.pkr.hcl
@@ -198,6 +198,7 @@ build {
   }
   provisioner "shell" {
     scripts = [
+      "./provision/core/action-archive-cache.sh",
       "./provision/core/llvm.sh",
       "./provision/core/golang.sh",
       "./provision/core/swiftlint.sh",

--- a/images/macos/templates/macOS-12.json
+++ b/images/macos/templates/macOS-12.json
@@ -185,6 +185,7 @@
             "type": "shell",
             "execute_command": "chmod +x {{ .Path }}; {{ .Vars }} {{ .Path }}",
             "scripts": [
+                "./provision/core/action-archive-cache.sh",
                 "./provision/core/llvm.sh",
                 "./provision/core/golang.sh",
                 "./provision/core/swiftlint.sh",

--- a/images/macos/templates/macOS-13.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.anka.pkr.hcl
@@ -194,6 +194,7 @@ build {
   }
   provisioner "shell" {
     scripts = [
+      "./provision/core/action-archive-cache.sh",
       "./provision/core/llvm.sh",
       "./provision/core/swiftlint.sh",
       "./provision/core/openjdk.sh",

--- a/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
+++ b/images/macos/templates/macOS-13.arm64.anka.pkr.hcl
@@ -194,6 +194,7 @@ build {
   }
   provisioner "shell" {
     scripts = [
+      "./provision/core/action-archive-cache.sh",
       "./provision/core/llvm.sh",
       "./provision/core/rust.sh",
       "./provision/core/gcc.sh",

--- a/images/macos/tests/ActionArchiveCache.Tests.ps1
+++ b/images/macos/tests/ActionArchiveCache.Tests.ps1
@@ -1,0 +1,15 @@
+Describe "ActionArchiveCache" {
+    Context "Action archive cache directory not empty" {
+        It "$HOME/actionarchivecache not empty" {
+            (Get-ChildItem -Path "$env:HOME/actionarchivecache/*.tar.gz" -Recurse).Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context "Action tarball not empty" {
+        $testCases = Get-ChildItem -Path "$env:HOME/actionarchivecache/*.tar.gz" -Recurse | ForEach-Object { @{ ActionTarball = $_.FullName } }
+        It "<ActionTarball>" -TestCases $testCases {
+            param ([string] $ActionTarball)
+            (Get-Item "$ActionTarball").Length | Should -BeGreaterThan 0
+        }
+    }
+}

--- a/images/win/scripts/Installers/Install-ActionArchiveCache.ps1
+++ b/images/win/scripts/Installers/Install-ActionArchiveCache.ps1
@@ -1,0 +1,18 @@
+################################################################################
+##  File:  Install-ActionArchiveCache.ps1
+##  Desc:  Install Action Archive Cache
+##         from https://github.com/actions/action-versions
+################################################################################
+
+if (-not (Test-Path $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE))
+{
+    Write-Host "Creating action archive cache folder"
+    New-Item -ItemType Directory -Path $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE | Out-Null
+}
+
+$downloadUrl = Get-GitHubPackageDownloadUrl -RepoOwner "actions" -RepoName "action-versions" -Version "latest" -UrlFilter "*action-versions.zip"
+Write-Host "Download Latest action-versions archive from $downloadUrl"
+$actionVersionsArchivePath = Start-DownloadWithRetry -Url $downloadUrl -Name "action-versions.zip"
+
+Write-Host "Expand action-versions archive"
+Extract-7Zip -Path $actionVersionsArchivePath -DestinationPath $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE

--- a/images/win/scripts/Installers/Update-ImageData.ps1
+++ b/images/win/scripts/Installers/Update-ImageData.ps1
@@ -42,3 +42,4 @@ $json | Out-File -FilePath $imageDataFile
 setx ImageVersion $env:IMAGE_VERSION /m
 setx ImageOS $env:IMAGE_OS /m
 setx AGENT_TOOLSDIRECTORY $env:AGENT_TOOLSDIRECTORY /m
+setx ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE $env:ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE /m

--- a/images/win/scripts/Tests/ActionArchiveCache.Tests.ps1
+++ b/images/win/scripts/Tests/ActionArchiveCache.Tests.ps1
@@ -1,0 +1,15 @@
+Describe "ActionArchiveCache" {
+    Context "Action archive cache directory not empty" {
+        It "C:\actionarchivecache not empty" {
+            (Get-ChildItem -Path "C:\actionarchivecache\*.zip" -Recurse).Count | Should -BeGreaterThan 0
+        }
+    }
+
+    Context "Action zipball not empty" {
+        $testCases = Get-ChildItem -Path "C:\actionarchivecache\*.zip" -Recurse | ForEach-Object { @{ ActionZipball = $_.FullName } }
+        It "<ActionZipball>" -TestCases $testCases {
+            param ([string] $ActionZipball)
+            (Get-Item "$ActionZipball").Length | Should -BeGreaterThan 0
+        }
+    }
+}

--- a/images/win/windows2019.json
+++ b/images/win/windows2019.json
@@ -146,6 +146,7 @@
                 "IMAGE_VERSION={{user `image_version`}}",
                 "IMAGE_OS={{user `image_os`}}",
                 "AGENT_TOOLSDIRECTORY={{user `agent_tools_directory`}}",
+                "ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE=C:\\actionarchivecache\\",
                 "IMAGEDATA_FILE={{user `imagedata_file`}}"
             ],
             "scripts": [
@@ -224,6 +225,7 @@
         {
             "type": "powershell",
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Install-ActionArchiveCache.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Ruby.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PyPy.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Toolset.ps1",

--- a/images/win/windows2022.json
+++ b/images/win/windows2022.json
@@ -130,6 +130,7 @@
                 "IMAGE_VERSION={{user `image_version`}}",
                 "IMAGE_OS={{user `image_os`}}",
                 "AGENT_TOOLSDIRECTORY={{user `agent_tools_directory`}}",
+                "ACTIONS_RUNNER_ACTION_ARCHIVE_CACHE=C:\\actionarchivecache\\",
                 "IMAGEDATA_FILE={{user `imagedata_file`}}"
             ],
             "scripts": [
@@ -214,6 +215,7 @@
         {
             "type": "powershell",
             "scripts": [
+                "{{ template_dir }}/scripts/Installers/Install-ActionArchiveCache.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Ruby.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-PyPy.ps1",
                 "{{ template_dir }}/scripts/Installers/Install-Toolset.ps1",


### PR DESCRIPTION
# Description

New tool

Fetching latest release from https://github.com/actions/action-versions

The latest release contain all tar.gz or zip of all versions of the top 5 used first-party actions (ex: `actions/checkout`).

With these cached on the hosted runner image, the hosted runner won't need to reach out to codeload to download those same assets over and over again.

**For new tools, please provide total size and installation time.**

The asset is about 120MB for both Windows and non-Windows, the download and unzip normally is less than 10s.
Since the assets is an archive of other archive, we only need to unzip the outer layer, after unzip the total size on disk are pretty much the same.

![image](https://github.com/TingluoHuang/runner-images/assets/1750815/7766cb30-96bb-4d07-802b-ea014c518a70)

#### Related issue:

https://github.com/github/actions-broker/issues/17

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
